### PR TITLE
config service

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ cd backend;
 pip install -r requirements.txt
 ```
 
+## Configuration
+
+Configuration can be found in the `backend/config.py` file. This configuration is shared with the web app and Cypress tests using the `/config` route.
+
 ## Running the web app
 
 Run the Angular frontend:
@@ -53,7 +57,7 @@ Run the Flask backend:
 
 ```
 cd backend;
-export FLASK_APP=magician-names.py;
+export FLASK_APP=backend.py;
 flask run --cert=adhoc;
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install -r requirements.txt
 
 Configuration can be found in the `backend/config.py` file. This configuration is shared with the web app and Cypress tests using the `/config` route.
 
+The only exception to this is the `apiUrl` defined in `src/environments` in the Angular app. You somehow need to [specify](https://angular.io/guide/build) where to find the `/config` route.
+
 ## Running the web app
 
 Run the Angular frontend:

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask_cors import CORS
+from config import web_app_url, api_url
 
 app = Flask(__name__)
 CORS(app)
@@ -7,6 +8,11 @@ CORS(app)
 @app.route("/names")
 def names():
     return {"names": ["Harry Houdini", "G.O.B", "Robert Harbin"]}
+
+@app.route("/config")
+def config():
+    return {"webAppUrl": web_app_url,
+            "apiUrl": api_url}
 
 if __name__ == "__main__":
     app.run(ssl_context='adhoc')

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,2 @@
+web_app_url = "http://localhost:4200/" # ng default
+api_url = "https://127.0.0.1:5000" # Flask default

--- a/mte/src/app/app.module.ts
+++ b/mte/src/app/app.module.ts
@@ -13,6 +13,9 @@ import { MagicianListComponent } from './magician-list/magician-list.component';
 import { TrickListComponent } from './trick-list/trick-list.component';
 import { MagicianDetailsComponent } from './magician-details/magician-details.component';
 
+import { ConfigService } from './config.service';
+import { MagiciansService } from './magicians.service';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -31,7 +34,7 @@ import { MagicianDetailsComponent } from './magician-details/magician-details.co
     ]),
     BrowserAnimationsModule,
   ],
-  providers: [],
+  providers: [ConfigService, MagiciansService],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/mte/src/app/config.service.ts
+++ b/mte/src/app/config.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from './../environments/environment';
 
 export interface Config {
   webAppUrl: string;
@@ -16,6 +17,6 @@ export class ConfigService {
   ) { }
 
   getConfig() {
-    return this.http.get<Config>('https://127.0.0.1:5000/config');
+    return this.http.get<Config>(`${environment.apiUrl}/config`);
   }
 }

--- a/mte/src/app/config.service.ts
+++ b/mte/src/app/config.service.ts
@@ -17,6 +17,6 @@ export class ConfigService {
   ) { }
 
   getConfig() {
-    return this.http.get<Config>(`${environment.apiUrl}/config`);
+    return this.http.get<Config>(`${environment.configUrl}/config`);
   }
 }

--- a/mte/src/app/config.service.ts
+++ b/mte/src/app/config.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+export interface Config {
+  webAppUrl: string;
+  apiUrl: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService {
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  getConfig() {
+    return this.http.get<Config>('https://127.0.0.1:5000/config');
+  }
+}

--- a/mte/src/app/magician-list/magician-list.component.html
+++ b/mte/src/app/magician-list/magician-list.component.html
@@ -1,7 +1,7 @@
 <h1>Magicians</h1>
 
 <ul>
-  <li *ngFor="let name of magicianNames; index as magicianId">
+  <li *ngFor="let name of magicianNames$ | async; index as magicianId">
     <a [routerLink]="['/magicians', magicianId]">{{ name }}</a>
   </li>
 </ul>

--- a/mte/src/app/magician-list/magician-list.component.ts
+++ b/mte/src/app/magician-list/magician-list.component.ts
@@ -1,25 +1,29 @@
 import { MagiciansService } from './../magicians.service';
 import { MagicianNames } from './../magicians.service';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 
 @Component({
   selector: 'app-magician-list',
   templateUrl: './magician-list.component.html',
   styleUrls: ['./magician-list.component.css']
 })
-export class MagicianListComponent implements OnInit {
+export class MagicianListComponent implements OnInit, OnDestroy {
   magicianNames;
+  subscription;
 
   constructor(
     private magiciansService: MagiciansService
     ) {}
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
 
   ngOnInit(): void {
     this.getMagicianNames();
   }
 
   getMagicianNames() {
-    this.magiciansService
+    this.subscription = this.magiciansService
       .getMagicianNames()
       .subscribe((response: MagicianNames) => {
         this.magicianNames = response.names;

--- a/mte/src/app/magician-list/magician-list.component.ts
+++ b/mte/src/app/magician-list/magician-list.component.ts
@@ -1,32 +1,25 @@
-import { MagiciansService } from './../magicians.service';
-import { MagicianNames } from './../magicians.service';
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Observable } from 'rxjs';
+import { MagiciansService, MagicianNames } from './../magicians.service';
+import { Component, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-magician-list',
   templateUrl: './magician-list.component.html',
   styleUrls: ['./magician-list.component.css']
 })
-export class MagicianListComponent implements OnInit, OnDestroy {
-  magicianNames;
-  subscription;
+export class MagicianListComponent implements OnInit {
+  magicianNames$: Observable<string[]>;
 
   constructor(
     private magiciansService: MagiciansService
     ) {}
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
-  }
 
   ngOnInit(): void {
-    this.getMagicianNames();
+    this.magicianNames$ = this.getMagicianNames();
   }
 
   getMagicianNames() {
-    this.subscription = this.magiciansService
-      .getMagicianNames()
-      .subscribe((response: MagicianNames) => {
-        this.magicianNames = response.names;
-      });
+    return this.magiciansService
+      .getMagicianNames();
   }
 }

--- a/mte/src/app/magicians.service.ts
+++ b/mte/src/app/magicians.service.ts
@@ -1,3 +1,5 @@
+import { ConfigService } from './config.service';
+import { Config } from './config.service'
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
@@ -12,10 +14,14 @@ export interface MagicianNames {
 })
 export class MagiciansService {
   constructor(
-    private http: HttpClient
+    private http: HttpClient,
+    private config: ConfigService
   ) { }
 
   getMagicianNames() {
+    this.config.getConfig().subscribe((config: Config) => {
+      console.log(config.apiUrl);
+    });
     return this.http.get<MagicianNames>('https://127.0.0.1:5000/names');
   }
 }

--- a/mte/src/app/magicians.service.ts
+++ b/mte/src/app/magicians.service.ts
@@ -2,8 +2,6 @@ import { ConfigService } from './config.service';
 import { Config } from './config.service'
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { catchError, retry } from 'rxjs/operators';
 
 export interface MagicianNames {
   names: string[];

--- a/mte/src/app/magicians.service.ts
+++ b/mte/src/app/magicians.service.ts
@@ -1,7 +1,9 @@
+import { magicianNames } from './magicians';
 import { ConfigService } from './config.service';
 import { Config } from './config.service'
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
 
 export interface MagicianNames {
   names: string[];
@@ -17,9 +19,23 @@ export class MagiciansService {
   ) { }
 
   getMagicianNames() {
-    this.config.getConfig().subscribe((config: Config) => {
-      console.log(config.apiUrl);
-    });
-    return this.http.get<MagicianNames>('https://127.0.0.1:5000/names');
+    // getConfig() returns an observable
+    // so you have to subscribe to it
+    // https://medium.com/@luukgruijs/understanding-creating-and-subscribing-to-observables-in-angular-426dbf0b04a3
+
+
+    // https://stackoverflow.com/questions/49630371/return-a-observable-from-a-subscription-with-rxjs
+    // map should return Observable
+    return this.config.getConfig().pipe(
+      map(config => {
+        const apiUrl = config.apiUrl;
+        return this.http.get<MagicianNames>(`${apiUrl}/names`);
+      })
+    );
+
+    // this.config.getConfig().subscribe((config) => {
+    //   const apiUrl = config.apiUrl;
+    //   console.log(this.http.get<MagicianNames>(`${apiUrl}/names`));
+    // });
   }
 }

--- a/mte/src/app/magicians.service.ts
+++ b/mte/src/app/magicians.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from './config.service';
 import { Config } from './config.service'
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { map } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 
 export interface MagicianNames {
   names: string[];
@@ -22,20 +22,13 @@ export class MagiciansService {
     // getConfig() returns an observable
     // so you have to subscribe to it
     // https://medium.com/@luukgruijs/understanding-creating-and-subscribing-to-observables-in-angular-426dbf0b04a3
-
-
     // https://stackoverflow.com/questions/49630371/return-a-observable-from-a-subscription-with-rxjs
     // map should return Observable
     return this.config.getConfig().pipe(
-      map(config => {
+      switchMap(config => {
         const apiUrl = config.apiUrl;
         return this.http.get<MagicianNames>(`${apiUrl}/names`);
       })
     );
-
-    // this.config.getConfig().subscribe((config) => {
-    //   const apiUrl = config.apiUrl;
-    //   console.log(this.http.get<MagicianNames>(`${apiUrl}/names`));
-    // });
   }
 }

--- a/mte/src/app/magicians.service.ts
+++ b/mte/src/app/magicians.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from './config.service';
 import { Config } from './config.service'
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { switchMap } from 'rxjs/operators';
+import { switchMap, map } from 'rxjs/operators';
 
 export interface MagicianNames {
   names: string[];
@@ -20,14 +20,15 @@ export class MagiciansService {
 
   getMagicianNames() {
     // getConfig() returns an observable
-    // so you have to subscribe to it
+    // this observable is modified a bit before it's passed on
     // https://medium.com/@luukgruijs/understanding-creating-and-subscribing-to-observables-in-angular-426dbf0b04a3
     // https://stackoverflow.com/questions/49630371/return-a-observable-from-a-subscription-with-rxjs
-    // map should return Observable
     return this.config.getConfig().pipe(
       switchMap(config => {
         const apiUrl = config.apiUrl;
-        return this.http.get<MagicianNames>(`${apiUrl}/names`);
+        return this.http.get<MagicianNames>(`${apiUrl}/names`).pipe(
+          map(response => response.names)
+        );
       })
     );
   }

--- a/mte/src/environments/environment.ts
+++ b/mte/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'https://127.0.0.1:5000'
 };
 
 /*

--- a/mte/src/environments/environment.ts
+++ b/mte/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://127.0.0.1:5000'
+  configUrl: 'https://127.0.0.1:5000'
 };
 
 /*


### PR DESCRIPTION
I want to avoid hardcoding configuration in the web app itself. That's why the backend provides a `/config` endpoint exposing all configuration variables.