### PR TITLE
Lazyload services and components

### DIFF
--- a/mte/src/app/app.module.ts
+++ b/mte/src/app/app.module.ts
@@ -1,40 +1,34 @@
-import { RouterModule } from '@angular/router';
-import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import {
-  MatTableModule,
-} from '@angular/material/table';
+import { MatTableModule } from '@angular/material/table';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule } from '@angular/common/http';
-
-import { MagicianListComponent } from './magician-list/magician-list.component';
-import { TrickListComponent } from './trick-list/trick-list.component';
-import { MagicianDetailsComponent } from './magician-details/magician-details.component';
-
 import { ConfigService } from './config.service';
+import { MagicianDetailsComponent } from './magician-details/magician-details.component';
+import { MagicianListComponent } from './magician-list/magician-list.component';
 import { MagiciansService } from './magicians.service';
+import { TrickListComponent } from './trick-list/trick-list.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    TrickListComponent,
     MagicianListComponent,
     MagicianDetailsComponent,
   ],
   imports: [
     HttpClientModule,
     BrowserModule,
-    MatTableModule,
     RouterModule.forRoot([
-      { path: 'trick-list', component: TrickListComponent },
+      { path: 'trick-list', loadChildren: () => import('./trick-list/trick-list.module').then(m => m.TrickListModule) },
       { path: 'magician-list', component: MagicianListComponent },
       { path: 'magicians/:magicianId', component: MagicianDetailsComponent },
     ]),
     BrowserAnimationsModule,
   ],
-  providers: [ConfigService, MagiciansService],
+  providers: [],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/mte/src/app/trick-list/trick-list.module.ts
+++ b/mte/src/app/trick-list/trick-list.module.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatTableModule } from '@angular/material/table';
+import { RouterModule } from '@angular/router';
+
+import { TrickListComponent } from './trick-list.component';
+
+@NgModule({
+  declarations: [TrickListComponent],
+  imports: [
+    CommonModule,
+    MatTableModule,
+    RouterModule.forChild([{
+      path: '', component: TrickListComponent
+    }])
+  ]
+})
+export class TrickListModule { }


### PR DESCRIPTION
PR to [lazyload](https://angular.io/guide/lazy-loading-ngmodules).

> By default, NgModules are eagerly loaded, which means that as soon as the app loads, so do all the NgModules, whether or not they are immediately necessary. Lazy loading helps keep initial bundle sizes smaller, which in turn helps decrease load times.